### PR TITLE
Rename TweetX to Loon

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Contributions are always welcome! Please take a look at the [contribution guidel
 - [traficante](https://github.com/golabek-co-uk/traficante) - An app that let you run cross database(eg. SqlServer and ElasticSearch) SQL queries
 - [Synfonia](https://github.com/jmacato/Synfonia) - A music-oriented media player built with AvaloniaUI and our own fork of SharpAudio with FFMPEG Integration.
 - [xDelta3 Cross GUI](https://github.com/dan0v/xdelta3-cross-gui) - A cross-platform GUI for creating patches using xDelta3 on Windows, Linux, and Mac.
-- [TweetX](https://github.com/mike-ward/TweetX) - TweetX is a cross platform desktop twitter client. It's minimal design mimics gadget style applications.
+- [Loon](https://github.com/mike-ward/Loon) - Loon is a cross platform desktop twitter client. It's minimal design mimics gadget style applications.
 
 ## Tutorials
 - [Quickstart](https://avaloniaui.net/docs/quickstart/) - Info for quick start with Avalonia UI.


### PR DESCRIPTION
Been trying to decide what to call this for week and figured I wasn't going to do any better than TweetX. Then inspiration takes over right after I issue a pull request. Sorry about that.