### PR TITLE
Add Avalonia Material Icon Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Contributions are always welcome! Please take a look at the [contribution guidel
 - [Svg.Skia](https://github.com/wieslawsoltes/Svg.Skia) - An SVG rendering library with an example of Avalonia.
 - [ThemeEditor](https://github.com/wieslawsoltes/ThemeEditor) - ThemeEditor is an Avalonia UI Framework theme editor.
 - [ThemeManager](https://github.com/wieslawsoltes/Avalonia.ThemeManager) - Theme manager for Avalonia applications.
+- [Avalonia Material Icon Pack](https://github.com/aboimpinto/MaterialDesign.Avalonia) - All Material Icons Pack that can be found in https://fonts.google.com/icons (net5.0 only).
 
 ## Books
 


### PR DESCRIPTION
Material Design Icon Pack that can be used isolated.
Easy to use

net5.0 only.