### PR TITLE
Add link checker workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -4,8 +4,10 @@ name: link-check
 
 # Controls when the workflow will run
 on:
+  # runs every monday at 9 am
   schedule:
-    - cron: 0 0 * * 0 # once a week on sunday
+    - cron: "0 9 * * 1"
+    
   # Triggers the workflow on push or pull request events but only for the "master" branch
   #push:
   #  branches: [ "master" ]

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,14 +1,16 @@
 # This is a basic workflow to help you get started with Actions
 
-name: L
+name: link-check
 
 # Controls when the workflow will run
 on:
+  schedule:
+    - cron: 0 0 * * 0 # once a week on sunday
   # Triggers the workflow on push or pull request events but only for the "master" branch
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+  #push:
+  #  branches: [ "master" ]
+  #pull_request:
+  #  branches: [ "master" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,22 @@
+# This is a basic workflow to help you get started with Actions
+
+name: L
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "master" branch
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -23,4 +23,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: becheran/mlc@v0.16.2


### PR DESCRIPTION
Uses markdown link checker (https://github.com/becheran/mlc) to analyze all links once a week or can be triggered manually.
The pipeline will fail if it detects 404s, but it will also produce warnings for redirects.
You can see how the output will look like here:
https://github.com/Mrxx99/awesome-avalonia/actions/runs/6136648764