### PR TITLE
Add SimpleRouter/SimpleRouter.Avalonia

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Contributions are always welcome! Please take a look at the [contribution guidel
 - [Nlnet.Avalonia.Css](https://github.com/liwuqingxin/Avalonia.Css) - A library for Avalonia to write styles like CSS.
 - [NP.Avalonia.Unidock](https://github.com/npolyak/NP.Avalonia.Unidock) - Simple VS2022-like window and view docking.
 - [Nukepayload2.SourceGenerators.AvaloniaUI](https://github.com/Nukepayload2/Nukepayload2.SourceGenerators.AvaloniaUI) - Visual Basic source generator for typed Avalonia `x:Name` References.
+- [IDotta.SimpleRouter](https://github.com/idotta/SimpleRouter) - A lightweight, routing/navigation library for .NET applications with platform specific extensions for AvaloniaUI.
 - [ShowMeTheXaml.Avalonia](https://github.com/AvaloniaUtils/ShowMeTheXaml.Avalonia) - A control that makes it easier to display the corresponding XAML at runtime.
 - [SpiroNet](https://github.com/wieslawsoltes/SpiroNet) - The .NET C# port of libspiro - conversion between spiro control points and bezier's.
 - [Verify.Avalonia](https://github.com/VerifyTests/Verify.Avalonia) - Extends Verify to allow verification of Avalonia UIs using headless testing.


### PR DESCRIPTION
Added my own library to the General section.

SimpleRouter is a library that makes it very easy to navigate through routes. It was inspired by ReactiveUI's navigation. It is very flexible and can be used in many different ways.
SimpleRouter.Avalonia is a package that simplifies view location and provides a `RouteViewHost`. The views can be created in many ways: with a DI container, through factories or even with the default reflection method used in older AvaloniaUI templates. The `RouteViewHost` behavior is similar to the `RoutedViewHost` from Avalonia.ReactiveUI.

There are nuget packages for SimpleRouter and SimpleRouter.Avalonia. There is also a sample application made using AvaloniaUI that can be tested directly in the browser through the repository [github pages](https://idotta.github.io/SimpleRouter/).