### PR TITLE
Add NodifyAvalonia

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Contributions are always welcome! Please take a look at the [contribution guidel
 - [MessageBox.Avalonia](https://github.com/AvaloniaCommunity/MessageBox.Avalonia) - Message Box UI for Avalonia UI.
 - [Movere](https://github.com/jp2masa/Movere) - Movere is an implementation of managed dialogs for Avalonia.
 - [NodifyM.Avalonia](https://github.com/MakesYT/NodifyM.Avalonia) - A collection of controls for node based editors designed for MVVM.
+- [NodifyAvalonia](https://github.com/BAndysc/nodify-avalonia) - Highly performant and modular controls for node-based editors designed for data-binding and MVVM. 1-1 port of WPF's version.
 - [Notification.Avalonia](https://github.com/AvaloniaCommunity/Notification.Avalonia) - Control for show different information in LINQ style.
 - [NP.Avalonia.Visuals](https://github.com/npolyak/NP.Avalonia.Visuals) - Additional visual controls by npolyak.
 - [Paginator.Avalonia](https://github.com/AvaloniaUtils/Paginator.Avalonia) - A paginator control.


### PR DESCRIPTION
This PR adds a link to my Port of WPF's Nodify library. Awesome-Avalonia repo already mentions an alternative port [NodifyM.Avalonia](https://github.com/MakesYT/NodifyM.Avalonia), but NodifyM.Avalonia is a bit outdated compared to my port and it is has more changes than my port, my intention is to keep as close as possible to the original so that wpf's upstream can be easily merged to me port.