### PR TITLE
Add links to Devolutions MacOS and DevExpress themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Contributions are always welcome! Please take a look at the [Contribution Guidel
 - [AntDesign.Avalonia](https://github.com/MicroSugarDeveloperOrg/AntDesign.Avalonia) - Avalonia Theme inspired by Ant Design.
 - [CherylUI](https://github.com/kikipoulet/CherylUI) - Avalonia UI Library for Mobile Applications.
 - [Classic.Avalonia](https://github.com/BAndysc/Classic.Avalonia) - Classic Windows 9x-like theme and controls for Avalonia.
+- [Devolutions.AvaloniaTheme.DevExpress](https://github.com/Devolutions/avalonia-extensions) - Avalonia Theme inspired by DevExpress.
+- [Devolutions.AvaloniaTheme.MacOS](https://github.com/Devolutions/avalonia-extensions) - Avalonia Theme inspired by MacOS.
 - [HeroIcons.Avalonia](https://github.com/russkyc/heroicons-avalonia) - Hand crafted icons from [Heroicons](https://heroicons.com) made available to AvaloniaUI.
 - [Icons.Avalonia](https://github.com/Projektanker/Icons.Avalonia) - A library to easily display icons in an Avalonia App.
 - [Lucide.Avalonia](https://github.com/dme-compunet/Lucide.Avalonia) - Implementation of the Lucide icon library for AvaloniaUI.

--- a/README.md
+++ b/README.md
@@ -200,8 +200,7 @@ Contributions are always welcome! Please take a look at the [Contribution Guidel
 - [AntDesign.Avalonia](https://github.com/MicroSugarDeveloperOrg/AntDesign.Avalonia) - Avalonia Theme inspired by Ant Design.
 - [CherylUI](https://github.com/kikipoulet/CherylUI) - Avalonia UI Library for Mobile Applications.
 - [Classic.Avalonia](https://github.com/BAndysc/Classic.Avalonia) - Classic Windows 9x-like theme and controls for Avalonia.
-- [Devolutions.AvaloniaTheme.DevExpress](https://github.com/Devolutions/avalonia-extensions) - Avalonia Theme inspired by DevExpress.
-- [Devolutions.AvaloniaTheme.MacOS](https://github.com/Devolutions/avalonia-extensions) - Avalonia Theme inspired by MacOS.
+- [Devolutions Avalonia-Extensions](https://github.com/Devolutions/avalonia-extensions) - Avalonia Themes for a MacOS or DevExpress look.
 - [HeroIcons.Avalonia](https://github.com/russkyc/heroicons-avalonia) - Hand crafted icons from [Heroicons](https://heroicons.com) made available to AvaloniaUI.
 - [Icons.Avalonia](https://github.com/Projektanker/Icons.Avalonia) - A library to easily display icons in an Avalonia App.
 - [Lucide.Avalonia](https://github.com/dme-compunet/Lucide.Avalonia) - Implementation of the Lucide icon library for AvaloniaUI.


### PR DESCRIPTION
This PR adds links to two of our themes in the 'Theme & Icon' section. (The links are intentionally the same, because both themes are in the same repo, and the main ReadMe seems a good entry point for both with some extra info)

Thanks for providing this great resource list!