### PR TITLE
Replace unmaintained Projektanker/Icons.Avalonia with Optris fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ Contributions are always welcome! Please take a look at the [Contribution Guidel
 - [Devolutions Avalonia-Extensions](https://github.com/Devolutions/avalonia-extensions) - Avalonia Themes for a MacOS or DevExpress look.
 - [HeroIcons.Avalonia](https://github.com/russkyc/heroicons-avalonia) - Hand crafted icons from [Heroicons](https://heroicons.com) made available to AvaloniaUI.
 - [Huskui.Avalonia](https://github.com/d3ara1n/Huskui.Avalonia) - A modern, elegant UI component library inspired by [ParkUI](https://park-ui.com/) and using the [Radix Colors](https://www.radix-ui.com/colors) palette.
-- [Icons.Avalonia](https://github.com/Projektanker/Icons.Avalonia) - A library to easily display icons in an Avalonia App.
 - [IconPacks.Avalonia](https://github.com/MahApps/IconPacks.Avalonia) Really awesome icon packs for Avalonia in one library. The IconPacks packages contains controls, markup extensions and converters to use these awesome icons with your Avalonia applications in a simple way.
 - [Lucide.Avalonia](https://github.com/dme-compunet/Lucide.Avalonia) - Implementation of the Lucide icon library for AvaloniaUI.
 - [LucideAvaloniaUI](https://github.com/MarwanFr/LucideAvaloniaUI) - A library for AvaloniaUI that integrates Lucide icons into your Avalonia applications.
@@ -232,6 +231,7 @@ Contributions are always welcome! Please take a look at the [Contribution Guidel
 - [Material Design](https://github.com/AvaloniaCommunity/Material.Avalonia) - Collection of styles to help you customize your Avalonia application theme with Material Design.
 - [Material.Icons.Avalonia](https://github.com/SKProCH/Material.Icons) - Lightweight library for easily display 6000+ icons from [MaterialDesignIcons](https://pictogrammers.com/library/mdi/?welcome)
 - [Neumorphism.Avalonia](https://github.com/flarive/Neumorphism.Avalonia) - Easy to use and customizable Neumorphism Design implementation for Avalonia.
+- [Optris.Icons.Avalonia](https://github.com/Optris/Optris.Icons.Avalonia) - A library to easily display icons in an Avalonia App. Maintained continuation of [Projektanker.Icons.Avalonia](https://github.com/Projektanker/Icons.Avalonia) (now unmaintained), with Avalonia 12 support and Font Awesome 6/7 + Material Design icon packs.
 - [Palette Designer](https://github.com/LaurentInSeattle/PaletteDesigner) - Interactive tool to generate beautiful color palettes, exporting to Adobe ASE, CSS, XAML, AXAML and JSON.
 - [Pipboy.Avalonia](https://github.com/NeverMorewd/Pipboy.Avalonia) - A Fallout 4 Pip-Boy inspired theme library for Avalonia UI.
 - [Romzetron.Avalonia](https://github.com/Romzetron/Romzetron.Avalonia) - Avalonia Theme that supports light/dark modes and a variety of color themes.


### PR DESCRIPTION
## Summary

Updates the **Theme & Icons** section to point to the maintained continuation of `Projektanker/Icons.Avalonia`.
**Users of Avalonia 12 will have their applications crash if they use [Projektanker/Icons.Avalonia](https://github.com/Projektanker/Icons.Avalonia)**

- The original [Projektanker/Icons.Avalonia](https://github.com/Projektanker/Icons.Avalonia) is no longer maintained — Projektanker GmbH has been dissolved and PRs to that repo are not being reviewed.
- [Optris GmbH](https://github.com/Optris) has adopted the project and is maintaining it as [Optris/Optris.Icons.Avalonia](https://github.com/Optris/Optris.Icons.Avalonia), with an Avalonia 12 port and ongoing FontAwesome / Material Design pack updates.
- The new entry is placed in the alphabetically correct position (between `Neumorphism.Avalonia` and `Palette Designer`); the old `Icons.Avalonia` line has been removed to avoid pointing readers at an abandoned repo.

The XAML XML namespace URL is preserved in the fork as an opaque identifier, so existing consumer XAML keeps working — only the NuGet package IDs and C# namespace changed (`Projektanker.Icons.Avalonia` → `Optris.Icons.Avalonia`).