### PR TITLE
Add ComeOnOver Desktop Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Contributions are always welcome! Please take a look at the [Contribution Guidel
 ### Productivity
 
 - [Betakads](https://github.com/ZadokJoshua/betakads-avalonia-app) - An AI-powered flashcards generator.
+- [ComeOnOver Desktop Launcher](https://github.com/LewisIsWorking/ComeOnOverDesktopLauncher) - A Windows launcher that manages multiple isolated Claude AI instances side by side, with per-slot resource monitoring, thumbnails, and auto-update via Velopack.
 - [Everywhere](https://github.com/DearVa/Everywhere) - Everywhere is a context-aware, interactive AI/LLM assistant built with .NET and Avalonia.
 - [iTimeSlot](https://github.com/hoyho/iTimeSlot) - A cross-platform and freestyle time management app for you to focus on completing tasks.
 - [Sapphire Notes](https://github.com/davidtimovski/sapphire-notes) - A cross-platform desktop application for managing notes.

--- a/README.md
+++ b/README.md
@@ -384,8 +384,8 @@ Contributions are always welcome! Please take a look at the [Contribution Guidel
 
 ## Artificial Intelligence
 
-- [ComeOnOver Desktop Launcher](https://github.com/LewisIsWorking/ComeOnOverDesktopLauncher) - A Windows launcher that manages multiple isolated Claude AI instances side by side, with per-slot resource monitoring, thumbnails, and auto-update via Velopack.
 - [Avalonia-Skills](https://github.com/linuxdevel/Avalonia-skills) - AI agent skills for OpenCode, Claude Code, and other agents — dense reference covering the full Avalonia framework (XAML, layout, styling, data binding, MVVM, controls, testing, deployment, and WPF migration). Install with a single `curl` command.
+- [ComeOnOver Desktop Launcher](https://github.com/LewisIsWorking/ComeOnOverDesktopLauncher) - A Windows launcher that manages multiple isolated Claude AI instances side by side, with per-slot resource monitoring, thumbnails, and auto-update via Velopack.
 
 ## Tooling
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Contributions are always welcome! Please take a look at the [Contribution Guidel
 ### Productivity
 
 - [Betakads](https://github.com/ZadokJoshua/betakads-avalonia-app) - An AI-powered flashcards generator.
-- [ComeOnOver Desktop Launcher](https://github.com/LewisIsWorking/ComeOnOverDesktopLauncher) - A Windows launcher that manages multiple isolated Claude AI instances side by side, with per-slot resource monitoring, thumbnails, and auto-update via Velopack.
 - [Everywhere](https://github.com/DearVa/Everywhere) - Everywhere is a context-aware, interactive AI/LLM assistant built with .NET and Avalonia.
 - [iTimeSlot](https://github.com/hoyho/iTimeSlot) - A cross-platform and freestyle time management app for you to focus on completing tasks.
 - [Sapphire Notes](https://github.com/davidtimovski/sapphire-notes) - A cross-platform desktop application for managing notes.
@@ -385,6 +384,7 @@ Contributions are always welcome! Please take a look at the [Contribution Guidel
 
 ## Artificial Intelligence
 
+- [ComeOnOver Desktop Launcher](https://github.com/LewisIsWorking/ComeOnOverDesktopLauncher) - A Windows launcher that manages multiple isolated Claude AI instances side by side, with per-slot resource monitoring, thumbnails, and auto-update via Velopack.
 - [Avalonia-Skills](https://github.com/linuxdevel/Avalonia-skills) - AI agent skills for OpenCode, Claude Code, and other agents — dense reference covering the full Avalonia framework (XAML, layout, styling, data binding, MVVM, controls, testing, deployment, and WPF migration). Install with a single `curl` command.
 
 ## Tooling


### PR DESCRIPTION
Adds ComeOnOver Desktop Launcher to the Productivity section.

**What it does:** Run multiple isolated Claude AI instances side by side on Windows. Each slot has its own login session, extensions, and MCP connections.

**Key features:**
- Up to 100 simultaneous Claude slots, each with a dedicated user-data directory
- Live CPU/RAM/uptime monitoring per slot (full Electron process tree aggregated to match Task Manager)
- Live window thumbnails + lightbox preview
- Hide/show windows to the system tray without terminating MCP connections
- Embedded Claude usage dashboard (WebView side panel)
- Per-slot activity signal: Active now / Active Xm ago / Idle
- Auto-update via Velopack with apply-failure detection

**Screenshot (v1.10.11):**

![ComeOnOver Desktop Launcher](https://raw.githubusercontent.com/LewisIsWorking/ComeOnOverDesktopLauncher/master/docs/screenshots/1.10.11.jpg)

Built with Avalonia 12, .NET 10, CommunityToolkit.Mvvm. 327 tests.