### PR TITLE
Add DevProjex dev-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Contributions are always welcome! Please take a look at the [Contribution Guidel
 - [AvalonStudio](https://github.com/VitalElement/AvalonStudio) - Cross-platform IDE and Shell.
 - [BlitzSearch](http://github.com/natestah/blitzSearch) - Windows, Find-in-Files Tool, an improved Find-in-files Experience for any IDE.
 - [DAGE](https://github.com/KvanTTT/DAGE) - DAGE is an Desktop Antlr grammar editor.
+- [DevProjex](https://github.com/Avazbek22/DevProjex) - A cross-platform desktop app for preparing clean project context for AI chats, reviews, and documentation.
 - [DevTools for Avalonia](https://www.devtools.nlnet.net) - A third-party interface debugging functionality for Avalonia, providing user-friendly and rich debugging features.
 - [FVim](https://github.com/yatli/fvim) - Cross-platform Neovim front-end UI, built with F# + Avalonia.
 - [Git-It-GUI](https://github.com/reignstudios/Git-It-GUI) - A Git GUI client designed to be simple with game studio collaboration in mind.


### PR DESCRIPTION
Adds DevProjex to the Software Development section. It is a cross-platform .NET/Avalonia codebase-context app with GUI, TUI, CLI, and a built-in read-only MCP server.